### PR TITLE
Remove pinned version from the module

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.10.0"
+      version = ">= 3.10.0"
     }
   }
 }


### PR DESCRIPTION
# Description

Please explain the changes you made here and link to any relevant issues.

Right now the module requires us to use v3.10.0, by changing this to >= there is still a minimum version maintained but people can be more flexible about the version used.

https://www.terraform.io/docs/language/expressions/version-constraints.html
_Reusable modules should constrain only their minimum allowed versions of Terraform and providers, such as >= 0.12.0. This helps avoid known incompatibilities, while allowing the user of the module flexibility to upgrade to newer versions of Terraform without altering the module._
