### PR TITLE
Unpins TF provider so newer versions can also be used

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.10.0"
+      version = "=> 3.10.0"
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Stefan Wessels Beljaars <swesselsbeljaars@schubergphilis.com>

# Description

Unpins TF provider so newer versions can also be used.

This follows-up: PR https://github.com/clouddrove/terraform-aws-ses/pull/12 (Closed w/o reason) and only contains a single commit.

Could you please merge or explain what is missing?