### PR TITLE
Fixes comparison operator in AWS provider version (Invalid version constraint)

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "=> 3.10.0"
+      version = ">= 3.10.0"
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Stefan Wessels Beljaars <swesselsbeljaars@schubergphilis.com>

# Description

Made a typo in the previous commit. Now works:
```
❯ terraform validate
Success! The configuration is valid.
```