### PR TITLE
fix(main): update domain references to use count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "aws_route53_record" "dkim" {
 #Description : Terraform module to create domain mail from on AWS
 resource "aws_ses_domain_mail_from" "default" {
   count            = var.enable_mail_from ? 1 : 0
-  domain           = aws_ses_domain_identity.default.*.domain
+  domain           = aws_ses_domain_identity.default[count.index].domain
   mail_from_domain = local.stripped_mail_from_domain
 }
 
@@ -145,7 +145,7 @@ data "aws_iam_policy_document" "document" {
 #Description : Terraform module to create ses identity policy on AWS
 resource "aws_ses_identity_policy" "default" {
   count    = var.enable_policy ? 1 : 0
-  identity = aws_ses_domain_identity.default.*.arn
+  identity = aws_ses_domain_identity.default[count.index].arn
   name     = var.policy_name
   policy   = data.aws_iam_policy_document.document.json
 }


### PR DESCRIPTION
## what
Fixes: 

```
| Error: Incorrect attribute value type
│ 
│   on .terraform/modules/example_ses/main.tf line 66, in resource "aws_ses_domain_mail_from" "default":
│   66:   domain           = aws_ses_domain_identity.default.*.domain
│     ├────────────────
│     │ aws_ses_domain_identity.default is tuple with 1 element
│ 
│ Inappropriate value for attribute "domain": string required.
```

Previously: 

```hcl
resource "aws_ses_identity_policy" "default" {
  count    = var.enable_policy ? 1 : 0
  identity = aws_ses_domain_identity.default.*.arn
  name     = var.policy_name
  policy   = data.aws_iam_policy_document.document.json
}
```

Terraform expects a single identity here instead of a list so it errors. Updating it to use the count index solves the issue.


```hcl 
resource "aws_ses_identity_policy" "default" {
  count    = var.enable_policy ? 1 : 0
  identity = aws_ses_domain_identity.default[count.index].arn
  name     = var.policy_name
  policy   = data.aws_iam_policy_document.document.json
}
```
## why
* The module cannot be applied without this change. 

## references
* Closes #16 
