### PR TITLE
use the iam_name as the aws_iam_user name property so the user and ke…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -191,7 +191,7 @@ resource "aws_ses_template" "default" {
 resource "aws_iam_user" "default" {
   count = var.enabled && var.iam_name != "" ? 1 : 0
 
-  name  = module.labels.id
+  name  = var.iam_name
 }
 
 # Module      : IAM ACCESS KEY


### PR DESCRIPTION
…ys can be retrieved from data.

## what

- Based on the recent updates the iam_name is now just a flag for creating the user, it's not actually used as the name.

## why
- Without using a previously defined iam_name or exporting the module.labels.id value we can't consistently retrieve the user or their keys for SMTP. So I opted to make iam_name used as that seems to be the intended purpose.
