### PR TITLE
add iam credentials to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ module "ses" {
 |------|-------------|
 | domain\_identity\_arn | ARN of the SES domain identity. |
 | id | The domain name of the domain identity. |
+| iam\_access\_key\_secret | The access key secret. |
+| iam\_access\_key\_id | The access key ID. |
 
 
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,13 @@
 #  value       = try(aws_ses_domain_identity_verification.default[0].id, "")
 #  description = "The domain name of the domain identity."
 #}
+
+output "iam_access_key_secret" {
+  description = "The access key secret."
+  value       = try(aws_iam_access_key.default[0].secret, "")
+  sensitive   = true
+}
+output "iam_access_key_id" {
+  description = "The access key ID."
+  value       = try(aws_iam_access_key.default[0].id, "")
+}


### PR DESCRIPTION
## what
* Added IAM credentials of the created user to outputs

## why
* It can be used for any case from the module. For example: passing them to the application

## references
* [issue #26](https://github.com/clouddrove/terraform-aws-ses/issues/26)
