### PR TITLE
Fix: 🐛 Fix domain identity not found in output issue.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 ##Module      : DOMAIN IDENTITY
 ## Description : Terraform module to create domain identity using domain
 output "domain_identity_arn" {
-  value       = aws_ses_domain_identity.default[0].arn
+  value       = try(aws_ses_domain_identity.default[0].arn, "")
   description = "ARN of the SES domain identity."
 }
 


### PR DESCRIPTION
## what
* Added Try function to prevent error when domain identity enabled is false.

## why
* getting error in output while removing domain identity, working fine without a single email identity.